### PR TITLE
Update Withings_Sleep_Sensor.groovy

### DIFF
--- a/drivers/Withings_Sleep_Sensor.groovy
+++ b/drivers/Withings_Sleep_Sensor.groovy
@@ -12,6 +12,8 @@
 metadata {
     definition(name: "Withings Sleep Sensor", namespace: "lnjustin", author: "dmeglio@gmail.com, lnjustin") {
         capability "Sensor"
+        capability "SleepSensor"
+        capability "Switch"
         capability "PresenceSensor"
         
         attribute "wakeupDuration", "number"
@@ -55,4 +57,22 @@ metadata {
         attribute "awakeAfterSleepQuality", "string"
         attribute "outOfBedCount", "number"
     }
+}
+
+def asleep() {
+	on()
+}
+
+def awake() {
+	off()
+}
+
+def on() {
+    sendEvent(name: "sleeping", value: "sleeping")
+    sendEvent(name: "switch", value: "on")
+}
+
+def off() {
+    sendEvent(name: "sleeping", value: "not sleeping")
+    sendEvent(name: "switch", value: "off")
 }


### PR DESCRIPTION
Add Sleep Sensor and Switch that sets Sleeping on and off.  I use the switch as an easier way to setup a RM rule to trigger my night routines to set the Ring Security when me and my wife is in bed.   The Sleep Sensor I use in my dashboard.